### PR TITLE
Make code compilable with MSVC

### DIFF
--- a/application/application.pro
+++ b/application/application.pro
@@ -159,7 +159,7 @@ SOURCES += ../dct_widgets/mcceqbox/mcceqbox.cpp                             \
            ../libraries/ctrl_protocol/ctrl_protocol_dpcc.c                  \
            ../libraries/ctrl_protocol/ctrl_protocol_lens.c                  \
            ../libraries/provideo_protocol/provideo_protocol.c               \
-           ../libraries/provideo_protocol/provideo_protocol_common.c        \
+           ../libraries/provideo_protocol/provideo_protocol_common.cpp      \
            ../libraries/provideo_protocol/provideo_protocol_system.c        \
            ../libraries/provideo_protocol/provideo_protocol_isp.c           \
            ../libraries/provideo_protocol/provideo_protocol_cproc.c         \

--- a/dct_widgets/com_ctrl/AutoItf.cpp
+++ b/dct_widgets/com_ctrl/AutoItf.cpp
@@ -188,15 +188,20 @@ void AutoItf::GetWbPresets( int const no )
     // Is there a signal listener
     if ( receivers(SIGNAL(WbPresetsChanged(int,QString,int))) > 0 )
     {
-        ctrl_protocol_wb_preset_t presets[no];
+        // g++ supports of Variable Length Arrays (VLA) as extension, standard C++ does not support it, so to compile with MSVC we use vector:
+        //ctrl_protocol_wb_preset_t presets[no]; VLA Fix:
+        std::vector<ctrl_protocol_wb_preset_t> presets(no);
+        
         int i;
 
         // clear memory
-        memset( presets, 0, sizeof( presets ) );
+        //memset( presets, 0, sizeof( presets ) ); VLA Fix:
+        memset( presets.data(), 0, sizeof( ctrl_protocol_wb_preset_t ) * no );
 
         // get auto processing white-blance presets from device
         int res = ctrl_protocol_get_wbpresets( GET_PROTOCOL_INSTANCE(this),
-                    GET_CHANNEL_INSTANCE(this), sizeof(presets), (uint8_t *)presets );
+                    //GET_CHANNEL_INSTANCE(this), sizeof(presets), (uint8_t *)presets ); VLA Fix:
+                    GET_CHANNEL_INSTANCE(this), sizeof(ctrl_protocol_wb_preset_t) * no, (uint8_t *)presets.data() );
         HANDLE_ERROR( res );
 
         // emit WbPresetsChanged signals

--- a/dct_widgets/com_ctrl/MccItf.cpp
+++ b/dct_widgets/com_ctrl/MccItf.cpp
@@ -117,7 +117,9 @@ void MccItf::GetMccPhase( int id )
     if ( receivers(SIGNAL(MccPhaseChanged(int,int,int))) > 0 )
     {
         ctrl_protocol_mcc_phase_t phase 
-            = { .id = (uint8_t)id, .saturation = 0u, .hue = 0 };
+            // designators in struct initialization are not supported by MSVC
+            //= { .id = (uint8_t)id, .saturation = 0u, .hue = 0 }; struct designators fix:
+            = { (uint8_t)id, 0u, 0 };
 
         int res = ctrl_protocol_get_mcc_phase( GET_PROTOCOL_INSTANCE(this),
             GET_CHANNEL_INSTANCE(this), sizeof(phase), (uint8_t *)&phase );
@@ -144,7 +146,8 @@ void MccItf::GetMccPhases( int mode )
         for ( unsigned id = 0u; id<phases; id++ )
         {
             ctrl_protocol_mcc_phase_t phase
-                = { .id = (uint8_t)id, .saturation = 0u, .hue = 0 };
+                //= { .id = (uint8_t)id, .saturation = 0u, .hue = 0 };struct designators fix:
+                = { (uint8_t)id, 0u, 0 };
 
             res = ctrl_protocol_get_mcc_phase( GET_PROTOCOL_INSTANCE(this),
                     GET_CHANNEL_INSTANCE(this), sizeof(phase), (uint8_t *)&phase );
@@ -205,7 +208,8 @@ void MccItf::onMccPhaseSelectionChange( int id )
 void MccItf::onMccPhaseChange( int id, int saturation, int hue )
 {
     ctrl_protocol_mcc_phase_t phase 
-        = { .id = (uint8_t)id, .saturation = (uint16_t)saturation, .hue = (int16_t)hue };
+        //= { .id = (uint8_t)id, .saturation = (uint16_t)saturation, .hue = (int16_t)hue };struct designators fix:
+        = { (uint8_t)id, (uint16_t)saturation, (int16_t)hue };
 
     // set mcc phase configuration on device
     int res = ctrl_protocol_set_mcc_phase( GET_PROTOCOL_INSTANCE(this),

--- a/libraries/provideo_protocol/provideo_protocol_common.cpp
+++ b/libraries/provideo_protocol/provideo_protocol_common.cpp
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include <vector> //  VLA Fix:
 
 #include <ctrl_channel/ctrl_channel.h>
 
@@ -389,7 +390,8 @@ int get_param_string
     char *                       param
 )
 {
-    char data[(lines*CMD_SINGLE_LINE_RESPONSE_SIZE)];
+    //char data[(lines*CMD_SINGLE_LINE_RESPONSE_SIZE)]; VLA Fix:
+    std::vector<char> data(lines*CMD_SINGLE_LINE_RESPONSE_SIZE);
 
     int res;
 
@@ -397,11 +399,13 @@ int get_param_string
     ctrl_channel_send_request( channel, (uint8_t *)cmd_get, strlen(cmd_get) );
 
     // read response from provideo device
-    res = evaluate_get_response( channel, data, sizeof(data) );
+    //res = evaluate_get_response( channel, data, sizeof(data) ); VLA Fix:
+    res = evaluate_get_response( channel, data.data(), data.size() );
     if ( !res )
     {
         // get start position of command
-        char * s = strstr( data, cmd_sync );
+        //char * s = strstr( data, cmd_sync ); VLA Fix:
+        char * s = strstr( data.data(), cmd_sync );
         if ( s )
         {
             // parse command
@@ -416,7 +420,8 @@ int get_param_string
     }
     else
     {
-        res = evaluate_error_response( data, res );
+        //res = evaluate_error_response( data, res ); VLA Fix:
+        res = evaluate_error_response( data.data(), res );
     }
 
     return ( res );
@@ -468,7 +473,8 @@ int get_param_int_X
     ...
 )
 {
-    char data[(lines*CMD_SINGLE_LINE_RESPONSE_SIZE)];
+    //char data[(lines*CMD_SINGLE_LINE_RESPONSE_SIZE)]; VLA Fix:
+    std::vector<char> data(lines*CMD_SINGLE_LINE_RESPONSE_SIZE);
 
     va_list args;
 
@@ -478,11 +484,13 @@ int get_param_int_X
     ctrl_channel_send_request( channel, (uint8_t *)cmd_get, strlen(cmd_get) );
 
     // read response from provideo device
-    res = evaluate_get_response( channel, data, sizeof(data) );
+    //res = evaluate_get_response( channel, data, sizeof(data) ); VLA Fix:
+    res = evaluate_get_response( channel, data.data(), data.size() );
     if ( !res )
     {
         // get start position of command
-        char * s = strstr( data, cmd_sync );
+        //char * s = strstr( data, cmd_sync ); VLA Fix:
+        char * s = strstr( data.data(), cmd_sync );
         if ( s )
         {
             // parse command
@@ -500,7 +508,8 @@ int get_param_int_X
     }
     else
     {
-        res = evaluate_error_response( data, res );
+        //res = evaluate_error_response( data, res ); VLA Fix:
+        res = evaluate_error_response( data.data(), res );
     }
 
     return ( res );
@@ -522,7 +531,8 @@ int get_param_int_X_with_tmo
     ...
 )
 {
-    char data[(lines*CMD_SINGLE_LINE_RESPONSE_SIZE)];
+    //char data[(lines*CMD_SINGLE_LINE_RESPONSE_SIZE)]; VLA Fix:
+    std::vector<char> data(lines*CMD_SINGLE_LINE_RESPONSE_SIZE);
 
     va_list args;
 
@@ -532,11 +542,13 @@ int get_param_int_X_with_tmo
     ctrl_channel_send_request( channel, (uint8_t *)cmd_get, strlen(cmd_get) );
 
     // read response from provideo device
-    res = evaluate_get_response_with_tmo( channel, data, sizeof(data), cmd_timeout_ms );
+    //res = evaluate_get_response_with_tmo( channel, data, sizeof(data), cmd_timeout_ms ); VLA Fix:
+    res = evaluate_get_response_with_tmo( channel, data.data(), data.size(), cmd_timeout_ms );
     if ( !res )
     {
         // get start position of command
-        char * s = strstr( data, cmd_sync );
+        //char * s = strstr( data, cmd_sync ); VLA Fix:
+        char * s = strstr( data.data(), cmd_sync );
         if ( s )
         {
             // parse command
@@ -554,7 +566,8 @@ int get_param_int_X_with_tmo
     }
     else
     {
-        res = evaluate_error_response( data, res );
+        //res = evaluate_error_response( data, res ); VLA Fix:
+        res = evaluate_error_response( data.data(), res );
     }
 
     return ( res );


### PR DESCRIPTION
1. VLA (Variable Length Array) is not supported by MSVC, so all usage were converted to std::vector
1a. Even in C files we got errors (although C compiler is supposed to support VLA, so .c files were renamed to .cpp to force C++ compilation mode and allow for std::vector usage.
all places marked with "VLA Fix:"

2. Struct initialization with designators ({ .id = (uint8_t)id, .saturation = 0u, .hue = 0 }) is not supported by MSVC
all places marked with "struct designators fix:"