### PR TITLE
Rename ProVideo to KAYA

### DIFF
--- a/application/application.pro
+++ b/application/application.pro
@@ -9,10 +9,10 @@
 VERSION = 1.1.15
 DEFINES += VERSION_STRING=\\\"1.1.15\\\"
 
-QMAKE_TARGET_COMPANY = "Dream Chip Technologies GmbH"
-QMAKE_TARGET_PRODUCT = "ProVideo GUI"
-QMAKE_TARGET_DESCRIPTION = "GUI to control ProVideo cameras and image processors"
-QMAKE_TARGET_COPYRIGHT = "Copyright (C) 2019, Dream Chip Technologies GmbH"
+QMAKE_TARGET_COMPANY = "KAYA Instruments"
+QMAKE_TARGET_PRODUCT = "SDI Control Point"
+QMAKE_TARGET_DESCRIPTION = "GUI to control KAYA SDI cameras"
+QMAKE_TARGET_COPYRIGHT = "Copyright (C) 2020, KAYA Instruments"
 
 RC_ICONS = ../resource/icons/dct_icon.ico
 
@@ -21,7 +21,7 @@ QT      += core serialport network
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-TARGET = ProVideo
+TARGET = SDIControlPoint
 TEMPLATE = app
 
 # Platform specific tweaks

--- a/dct_widgets/connectdialog/connectdialog.ui
+++ b/dct_widgets/connectdialog/connectdialog.ui
@@ -32,7 +32,7 @@
    <enum>Qt::NoContextMenu</enum>
   </property>
   <property name="windowTitle">
-   <string>Connect to ProVideo Device</string>
+   <string>Connect to KAYA Device</string>
   </property>
   <property name="windowIcon">
    <iconset resource="../../resource/resource.qrc">

--- a/dct_widgets/lensdriverbox/lensdriverbox.cpp
+++ b/dct_widgets/lensdriverbox/lensdriverbox.cpp
@@ -843,7 +843,7 @@ LensDriverBox::LensDriverBox( QWidget * parent ) : DctWidgetBox( parent )
                               "The template file for the supported lenses was not found. "
                               "Please make sure that the file 'SupportedLenses.txt' is "
                               "placed in a folder named 'tools_and_configs' which is placed "
-                              "in the same folder that 'ProVideo.exe' is placed.\n\n"
+                              "in the same folder that 'SDIControlPoint.exe' is placed.\n\n"
                               "Please restart the GUI after the file was restored to use"
                               "the available templates." );
     }


### PR DESCRIPTION
1. Dream Chip was renamed to KAYA
2. ProVideo was renamed to SDIControlPoint
3. ProVideo cameras was renamed to KAYA SDI cameras